### PR TITLE
Update bindings to ImGui v1.4.9

### DIFF
--- a/source/derelict/imgui/funcs.d
+++ b/source/derelict/imgui/funcs.d
@@ -129,6 +129,7 @@ extern(C) @nogc nothrow
     alias da_igEndGroup                 = void              function();
     alias da_igSeparator                    = void              function();
     alias da_igSameLine                     = void              function(float pos_x = 0.0f, float spacing_w = -1.0f);
+    alias da_igNewLine                      = void              function();
     alias da_igSpacing                      = void              function();
     alias da_igDummy                       = void              function(const ImVec2* size);
     alias da_igIndent                       = void              function();
@@ -551,6 +552,7 @@ __gshared
     da_igEndGroup igEndGroup;
     da_igSeparator igSeparator;
     da_igSameLine igSameLine;
+    da_igNewLine igNewLine;
     da_igSpacing igSpacing;
     da_igDummy igDummy;
     da_igIndent igIndent;

--- a/source/derelict/imgui/funcs.d
+++ b/source/derelict/imgui/funcs.d
@@ -305,6 +305,7 @@ extern(C) @nogc nothrow
     alias da_igIsItemHovered                = bool              function();
     alias da_igIsItemHoveredRect            = bool              function();
     alias da_igIsItemActive             = bool              function();
+    alias da_igIsItemClicked            = bool             function(int mouse_button);
     alias da_igIsItemVisible               = bool              function();
     alias da_igIsAnyItemHovered            = bool              function();
     alias da_igIsAnyItemActive             = bool              function();
@@ -713,6 +714,7 @@ __gshared
     da_igIsItemHovered igIsItemHovered;
     da_igIsItemHoveredRect igIsItemHoveredRect;
     da_igIsItemActive igIsItemActive;
+    da_igIsItemClicked igIsItemClicked;
     da_igIsItemVisible igIsItemVisible;
     da_igIsAnyItemHovered igIsAnyItemHovered;
     da_igIsAnyItemActive igIsAnyItemActive;

--- a/source/derelict/imgui/funcs.d
+++ b/source/derelict/imgui/funcs.d
@@ -183,7 +183,6 @@ extern(C) @nogc nothrow
     alias da_igInvisibleButton              = bool              function(const char* str_id, const ImVec2 size);
     alias da_igImage                        = void              function(ImTextureID user_texture_id, const ImVec2 size, const ImVec2 uv0 = ImVec2(0, 0), const ImVec2 uv1 = ImVec2(1, 1), const ImVec4 tint_col = ImVec4(1, 1, 1, 1), const ImVec4 border_col = ImVec4(0, 0, 0, 0));
     alias da_igImageButton                  = bool              function(ImTextureID user_texture_id, const ImVec2 size, const ImVec2 uv0 = ImVec2(0, 0), const ImVec2 uv1 = ImVec2(1, 1), int frame_padding = -1, const ImVec4 bg_col = ImVec4(0, 0, 0, 0), const ImVec4 tint_col = ImVec4(1, 1, 1, 1));
-    alias da_igCollapsingHeader         = bool              function(const char* label, const char* str_id = null, bool display_frame = true, bool default_open = false);
     alias da_igCheckbox                 = bool              function(const char* label, bool* v);
     alias da_igCheckboxFlags                = bool              function(const char* label, uint* flags, uint flags_value);
     alias da_igRadioButtonBool                  = bool              function(const char* label, bool active);
@@ -251,6 +250,8 @@ extern(C) @nogc nothrow
     alias da_igTreeAdvanceToLabelPos        = void              function();
     alias da_igGetTreeNodeToLabelSpacing    = float             function();
     alias da_igSetNextTreeNodeOpened        = void              function(bool opened, ImGuiSetCond cond = 0);
+    alias da_igCollapsingHeader             = bool             function(const char* label, ImGuiTreeNodeFlags flags = 0);
+    alias da_igCollapsingHeaderEx           = bool             function(const char* label, bool* p_open, ImGuiTreeNodeFlags flags = 0);
 
     alias da_igSelectable                   = bool              function(const char* label, bool selected = false, ImGuiSelectableFlags flags = 0, const ImVec2 size = ImVec2(0, 0));
     alias da_igSelectableEx             = bool              function(const char* label, bool* p_selected, ImGuiSelectableFlags flags = 0, const ImVec2 size = ImVec2(0, 0));
@@ -607,7 +608,6 @@ __gshared
     da_igInvisibleButton igInvisibleButton;
     da_igImage igImage;
     da_igImageButton igImageButton;
-    da_igCollapsingHeader igCollapsingHeader;
     da_igCheckbox igCheckbox;
     da_igCheckboxFlags igCheckboxFlags;
     da_igRadioButtonBool igRadioButtonBool;
@@ -676,6 +676,8 @@ __gshared
     da_igTreeAdvanceToLabelPos igTreeAdvanceToLabelPos;
     da_igGetTreeNodeToLabelSpacing igGetTreeNodeToLabelSpacing;
     da_igSetNextTreeNodeOpened igSetNextTreeNodeOpened;
+    da_igCollapsingHeader igCollapsingHeader;
+    da_igCollapsingHeaderEx igCollapsingHeaderEx;
 
     da_igSelectable igSelectable;
     da_igSelectableEx igSelectableEx;

--- a/source/derelict/imgui/funcs.d
+++ b/source/derelict/imgui/funcs.d
@@ -239,6 +239,11 @@ extern(C) @nogc nothrow
     alias da_igTreeNodePtr                  = bool              function(const void* ptr_id, const char* fmt, ...);
     alias da_igTreeNodeStrV                 = bool              function(const char* str_id, const char* fmt, va_list args);
     alias da_igTreeNodePtrV                 = bool              function(const void* ptr_id, const char* fmt, va_list args);
+    alias da_igTreeNodeEx                   = bool              function(const char* label, ImGuiTreeNodeFlags flags);
+    alias da_igTreeNodeExStr                = bool              function(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, ...);
+    alias da_igTreeNodeExPtr                = bool              function(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, ...);
+    alias da_igTreeNodeExV                  = bool              function(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args);
+    alias da_igTreeNodeExVPtr               = bool              function(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args);
     alias da_igTreePushStr                  = void              function(const char* str_id = null);
     alias da_igTreePushPtr                  = void              function(const void* ptr_id = null);
     alias da_igTreePop                      = void              function();
@@ -654,6 +659,11 @@ __gshared
     da_igTreeNodePtr igTreeNodePtr;
     da_igTreeNodeStrV igTreeNodeStrV;
     da_igTreeNodePtrV igTreeNodePtrV;
+    da_igTreeNodeEx igTreeNodeEx;
+    da_igTreeNodeExStr igTreeNodeExStr;
+    da_igTreeNodeExPtr igTreeNodeExPtr;
+    da_igTreeNodeExV igTreeNodeExV;
+    da_igTreeNodeExVPtr igTreeNodeExVPtr;
     da_igTreePushStr igTreePushStr;
     da_igTreePushPtr igTreePushPtr;
     da_igTreePop igTreePop;

--- a/source/derelict/imgui/funcs.d
+++ b/source/derelict/imgui/funcs.d
@@ -413,12 +413,14 @@ extern(C) @nogc nothrow
 	alias da_ImDrawList_PushTextureID = void function(ImDrawList* list, const ImTextureID texture_id);
 	alias da_ImDrawList_PopTextureID = void function(ImDrawList* list);
 	alias da_ImDrawList_AddLine = void function(ImDrawList* list, const ImVec2 a, const ImVec2 b, ImU32 col, float thickness = 1.0f);
-	alias da_ImDrawList_AddRect = void function(ImDrawList* list, const ImVec2 a, const ImVec2 b, ImU32 col, float rounding, int rounding_corners, float thickness);
+	alias da_ImDrawList_AddRect = void function(ImDrawList* list, const ImVec2 a, const ImVec2 b, ImU32 col, float rounding, int rounding_corners, float thickness = 1.0f);
 	alias da_ImDrawList_AddRectFilled = void function(ImDrawList* list, const ImVec2 a, const ImVec2 b, ImU32 col, float rounding = 0.0f, int rounding_corners = 0x0F);
 	alias da_ImDrawList_AddRectFilledMultiColor = void function(ImDrawList* list, const ImVec2 a, const ImVec2 b, ImU32 col_upr_left, ImU32 col_upr_right, ImU32 col_bot_right, ImU32 col_bot_left);
-	alias da_ImDrawList_AddTriangle = void function(ImDrawList* list, const ImVec2 a, const ImVec2 b, const ImVec2 c, ImU32 col, float thickness);
+	alias da_ImDrawList_AddQuad = void function(ImDrawList* list, const ImVec2 a, const ImVec2 b, const ImVec2 c, const ImVec2 d, ImU32 col, float thickness = 1.0f);
+    alias da_ImDrawList_AddQuadFilled = void function(ImDrawList* list, const ImVec2 a, const ImVec2 b, const ImVec2 c, const ImVec2 d, ImU32 col);
+    alias da_ImDrawList_AddTriangle = void function(ImDrawList* list, const ImVec2 a, const ImVec2 b, const ImVec2 c, ImU32 col, float thickness = 1.0f);
 	alias da_ImDrawList_AddTriangleFilled = void function(ImDrawList* list, const ImVec2 a, const ImVec2 b, const ImVec2 c, ImU32 col);
-	alias da_ImDrawList_AddCircle = void function(ImDrawList* list, const ImVec2 centre, float radius, ImU32 col, int num_segments, float thickness);
+	alias da_ImDrawList_AddCircle = void function(ImDrawList* list, const ImVec2 centre, float radius, ImU32 col, int num_segments, float thickness = 1.0f);
 	alias da_ImDrawList_AddCircleFilled = void function(ImDrawList* list, const ImVec2 centre, float radius, ImU32 col, int num_segments = 12);
 	alias da_ImDrawList_AddText = void function(ImDrawList* list, const ImVec2 pos, ImU32 col, const char* text_begin, const char* text_end = null);
 	alias da_ImDrawList_AddTextExt = void function(ImDrawList* list, const ImFont* font, float font_size, const ImVec2 pos, ImU32 col, const char* text_begin, const char* text_end = null, float wrap_width = 0.0f, const ImVec4* cpu_fine_clip_rect = null);
@@ -819,6 +821,8 @@ __gshared
 	da_ImDrawList_AddRect ImDrawList_AddRect;
 	da_ImDrawList_AddRectFilled ImDrawList_AddRectFilled;
 	da_ImDrawList_AddRectFilledMultiColor ImDrawList_AddRectFilledMultiColor;
+    da_ImDrawList_AddQuad ImDrawList_AddQuad;
+    da_ImDrawList_AddQuadFilled ImDrawList_AddQuadFilled;
 	da_ImDrawList_AddTriangle ImDrawList_AddTriangle;
 	da_ImDrawList_AddTriangleFilled ImDrawList_AddTriangleFilled;
 	da_ImDrawList_AddCircle ImDrawList_AddCircle;

--- a/source/derelict/imgui/funcs.d
+++ b/source/derelict/imgui/funcs.d
@@ -453,6 +453,14 @@ extern(C) @nogc nothrow
 	alias da_ImDrawList_UpdateTextureID = void function(ImDrawList* list);
 }
 
+// ImGuiListClipper methods
+extern(C) @nogc nothrow
+{
+    alias da_ImGuiListClipper_Begin = void function(ImGuiListClipper* clipper, int items_count, float items_height = -1.0f);
+    alias da_ImGuiListClipper_End = void function(ImGuiListClipper* clipper);
+    alias da_ImGuiListClipper_Step = bool function(ImGuiListClipper* clipper);
+}
+
 __gshared
 {
     da_igGetIO igGetIO;
@@ -860,4 +868,11 @@ __gshared
     da_ImGuiIO_AddInputCharacter ImGuiIO_AddInputCharacter;
     da_ImGuiIO_AddInputCharactersUTF8 ImGuiIO_AddInputCharactersUTF8;
     da_ImGuiIO_ClearInputCharacters ImGuiIO_ClearInputCharacters;
+}
+
+__gshared
+{
+    da_ImGuiListClipper_Begin ImGuiListClipper_Begin;
+    da_ImGuiListClipper_End ImGuiListClipper_End;
+    da_ImGuiListClipper_Step ImGuiListClipper_Step;
 }

--- a/source/derelict/imgui/funcs.d
+++ b/source/derelict/imgui/funcs.d
@@ -291,6 +291,9 @@ extern(C) @nogc nothrow
     alias da_igLogButtons       = void              function();
     alias da_igLogText          = void              function(const char* fmt, ...);
 
+    alias da_igPushClipRect     = void             function(const ImVec2 clip_rect_min, const ImVec2 clip_rect_max, bool intersect_with_current_clip_rect);
+    alias da_igPopClipRect      = void             function();
+
     alias da_igIsItemHovered                = bool              function();
     alias da_igIsItemHoveredRect            = bool              function();
     alias da_igIsItemActive             = bool              function();
@@ -392,7 +395,7 @@ extern(C) @nogc nothrow
     //---------------------------------------------------
 	alias da_ImDrawList_Clear = void function(ImDrawList* list);
 	alias da_ImDrawList_ClearFreeMemory = void function(ImDrawList* list);
-	alias da_ImDrawList_PushClipRect = void function(ImDrawList* list, const ImVec4 clip_rect);
+	alias da_ImDrawList_PushClipRect = void function(ImDrawList* list, ImVec2 clip_rect_min, ImVec2 clip_rect_max, bool intersect_with_current_clip_rect);
 	alias da_ImDrawList_PushClipRectFullScreen = void function(ImDrawList* list);
 	alias da_ImDrawList_PopClipRect = void function(ImDrawList* list);
 	alias da_ImDrawList_PushTextureID = void function(ImDrawList* list, const ImTextureID texture_id);
@@ -685,6 +688,9 @@ __gshared
     da_igLogFinish igLogFinish;
     da_igLogButtons igLogButtons;
     da_igLogText igLogText;
+
+    da_igPushClipRect igPushClipRect;
+    da_igPopClipRect igPopClipRect;
 
     da_igIsItemHovered igIsItemHovered;
     da_igIsItemHoveredRect igIsItemHoveredRect;

--- a/source/derelict/imgui/funcs.d
+++ b/source/derelict/imgui/funcs.d
@@ -247,6 +247,8 @@ extern(C) @nogc nothrow
     alias da_igTreePushStr                  = void              function(const char* str_id = null);
     alias da_igTreePushPtr                  = void              function(const void* ptr_id = null);
     alias da_igTreePop                      = void              function();
+    alias da_igTreeAdvanceToLabelPos        = void              function();
+    alias da_igGetTreeNodeToLabelSpacing    = float             function();
     alias da_igSetNextTreeNodeOpened        = void              function(bool opened, ImGuiSetCond cond = 0);
 
     alias da_igSelectable                   = bool              function(const char* label, bool selected = false, ImGuiSelectableFlags flags = 0, const ImVec2 size = ImVec2(0, 0));
@@ -667,6 +669,8 @@ __gshared
     da_igTreePushStr igTreePushStr;
     da_igTreePushPtr igTreePushPtr;
     da_igTreePop igTreePop;
+    da_igTreeAdvanceToLabelPos igTreeAdvanceToLabelPos;
+    da_igGetTreeNodeToLabelSpacing igGetTreeNodeToLabelSpacing;
     da_igSetNextTreeNodeOpened igSetNextTreeNodeOpened;
 
     da_igSelectable igSelectable;

--- a/source/derelict/imgui/funcs.d
+++ b/source/derelict/imgui/funcs.d
@@ -75,6 +75,7 @@ extern(C) @nogc nothrow
     alias da_igSetNextWindowPos             = void function(const ImVec2 pos, ImGuiSetCond cond = 0);
     alias da_igSetNextWindowPosCenter       = void function(ImGuiSetCond cond = 0);
     alias da_igSetNextWindowSize            = void function(const ImVec2 size, ImGuiSetCond cond = 0);
+    alias da_igSetNextWindowSizeConstraints = void function(const ImVec2 size_min, const ImVec2 size_max, ImGuiSizeConstraintCallback custom_callback = null, void* custom_callback_data = null);
     alias da_igSetNextWindowCollapsed       = void function(bool collapsed, ImGuiSetCond cond = 0);
     alias da_igSetNextWindowFocus           = void function();
     alias da_igSetWindowPos                 = void function(const ImVec2 pos, ImGuiSetCond cond = 0);
@@ -471,6 +472,7 @@ __gshared
     da_igSetNextWindowPos igSetNextWindowPos;
     da_igSetNextWindowPosCenter igSetNextWindowPosCenter;
     da_igSetNextWindowSize igSetNextWindowSize;
+    da_igSetNextWindowSizeConstraints igSetNextWindowSizeConstraints;
     da_igSetNextWindowCollapsed igSetNextWindowCollapsed;
     da_igSetNextWindowFocus igSetNextWindowFocus;
     da_igSetWindowPos igSetWindowPos;

--- a/source/derelict/imgui/funcs.d
+++ b/source/derelict/imgui/funcs.d
@@ -308,6 +308,7 @@ extern(C) @nogc nothrow
     alias da_igIsWindowFocused              = bool              function();
     alias da_igIsRootWindowFocused          = bool              function();
     alias da_igIsRootWindowOrAnyChildFocused    = bool              function();
+    alias da_igIsRootWindowOrAnyChildHovered    = bool              function();
     alias da_igIsRectVisible                    = bool              function(const ImVec2 item_size);
 
     alias da_igGetKeyIndex                  = int               function(ImGuiKey key);
@@ -706,6 +707,7 @@ __gshared
     da_igIsWindowFocused igIsWindowFocused;
     da_igIsRootWindowFocused igIsRootWindowFocused;
     da_igIsRootWindowOrAnyChildFocused igIsRootWindowOrAnyChildFocused;
+    da_igIsRootWindowOrAnyChildHovered igIsRootWindowOrAnyChildHovered;
     da_igIsRectVisible igIsRectVisible;
 
     da_igGetKeyIndex igGetKeyIndex;

--- a/source/derelict/imgui/funcs.d
+++ b/source/derelict/imgui/funcs.d
@@ -132,8 +132,8 @@ extern(C) @nogc nothrow
     alias da_igNewLine                      = void              function();
     alias da_igSpacing                      = void              function();
     alias da_igDummy                       = void              function(const ImVec2* size);
-    alias da_igIndent                       = void              function();
-    alias da_igUnindent                 = void              function();
+    alias da_igIndent                       = void              function(float indent_w);
+    alias da_igUnindent                 = void              function(float indent_w);
     alias da_igGetCursorPos             = void          function(ImVec2* pOut);
     alias da_igGetCursorPosX                = float         function();
     alias da_igGetCursorPosY                = float         function();

--- a/source/derelict/imgui/funcs.d
+++ b/source/derelict/imgui/funcs.d
@@ -249,7 +249,7 @@ extern(C) @nogc nothrow
     alias da_igTreePop                      = void              function();
     alias da_igTreeAdvanceToLabelPos        = void              function();
     alias da_igGetTreeNodeToLabelSpacing    = float             function();
-    alias da_igSetNextTreeNodeOpened        = void              function(bool opened, ImGuiSetCond cond = 0);
+    alias da_igSetNextTreeNodeOpen        = void              function(bool opened, ImGuiSetCond cond = 0);
     alias da_igCollapsingHeader             = bool             function(const char* label, ImGuiTreeNodeFlags flags = 0);
     alias da_igCollapsingHeaderEx           = bool             function(const char* label, bool* p_open, ImGuiTreeNodeFlags flags = 0);
 
@@ -677,7 +677,7 @@ __gshared
     da_igTreePop igTreePop;
     da_igTreeAdvanceToLabelPos igTreeAdvanceToLabelPos;
     da_igGetTreeNodeToLabelSpacing igGetTreeNodeToLabelSpacing;
-    da_igSetNextTreeNodeOpened igSetNextTreeNodeOpened;
+    da_igSetNextTreeNodeOpen igSetNextTreeNodeOpen;
     da_igCollapsingHeader igCollapsingHeader;
     da_igCollapsingHeaderEx igCollapsingHeaderEx;
 

--- a/source/derelict/imgui/funcs.d
+++ b/source/derelict/imgui/funcs.d
@@ -346,6 +346,12 @@ extern(C) @nogc nothrow
     alias da_igGetClipboardText             = const(char)* function();
     alias da_igSetClipboardText             = void function(const(char)* text);
 
+    alias da_igGetVersion                   = const(char)*      function();
+    alias da_igCreateContext                = ImGuiContext*    function(void* function(size_t) malloc_fn = null, void function(void*) free_fn = null);
+    alias da_igDestroyContext               = void                    function(ImGuiContext* ctx);
+    alias da_igGetCurrentContext            = ImGuiContext*    function();
+    alias da_igSetCurrentContext            = void                    function(ImGuiContext* ctx);
+
     alias da_igGetTime                      = float         function();
     alias da_igGetFrameCount                = int               function();
     alias da_igGetStyleColName             = const(char)*       function(ImGuiCol idx);
@@ -360,11 +366,6 @@ extern(C) @nogc nothrow
     alias da_igColorConvertFloat4ToU32      = ImU32 function(const ImVec4 in_);
     alias da_igColorConvertRGBtoHSV     = void function(float r, float g, float b, float* out_h, float* out_s, float* out_v);
     alias da_igColorConvertHSVtoRGB     = void function(float h, float s, float v, float* out_r, float* out_g, float* out_b);
-
-    alias da_igGetVersion                   = const(char)*      function();
-    alias da_igGetInternalState         = void*         function();
-    alias da_igGetInternalStateSize     = size_t            function();
-    alias da_igSetInternalState         = void              function(void* state, bool construct = false);
 }
 
 // ImFontAtlas Methods
@@ -752,6 +753,12 @@ __gshared
     da_igGetClipboardText igGetClipboardText;
     da_igSetClipboardText igSetClipboardText;
 
+    da_igGetVersion igGetVersion;
+    da_igCreateContext igCreateContext;
+    da_igDestroyContext igDestroyContext;
+    da_igGetCurrentContext igGetCurrentContext;
+    da_igSetCurrentContext igSetCurrentContext;
+
     da_igGetTime igGetTime;
     da_igGetFrameCount igGetFrameCount;
     da_igGetStyleColName igGetStyleColName;
@@ -766,11 +773,6 @@ __gshared
     da_igColorConvertFloat4ToU32 igColorConvertFloat4ToU32;
     da_igColorConvertRGBtoHSV igColorConvertRGBtoHSV;
     da_igColorConvertHSVtoRGB igColorConvertHSVtoRGB;
-
-    da_igGetVersion igGetVersion;
-    da_igGetInternalState igGetInternalState;
-    da_igGetInternalStateSize igGetInternalStateSize;
-    da_igSetInternalState igSetInternalState;
 }
 
 __gshared

--- a/source/derelict/imgui/imgui.d
+++ b/source/derelict/imgui/imgui.d
@@ -433,6 +433,8 @@ final class DerelictImguiLoader : SharedLibLoader
 			bindFunc(cast(void**)&ImDrawList_AddRect, "ImDrawList_AddRect");
 			bindFunc(cast(void**)&ImDrawList_AddRectFilled, "ImDrawList_AddRectFilled");
 			bindFunc(cast(void**)&ImDrawList_AddRectFilledMultiColor, "ImDrawList_AddRectFilledMultiColor");
+            bindFunc(cast(void**)&ImDrawList_AddQuad, "ImDrawList_AddQuad");
+            bindFunc(cast(void**)&ImDrawList_AddQuadFilled, "ImDrawList_AddQuadFilled");
 			bindFunc(cast(void**)&ImDrawList_AddTriangleFilled, "ImDrawList_AddTriangleFilled");
 			bindFunc(cast(void**)&ImDrawList_AddTriangle, "ImDrawList_AddTriangle");
 			bindFunc(cast(void**)&ImDrawList_AddCircle, "ImDrawList_AddCircle");

--- a/source/derelict/imgui/imgui.d
+++ b/source/derelict/imgui/imgui.d
@@ -296,7 +296,7 @@ final class DerelictImguiLoader : SharedLibLoader
                 bindFunc(cast(void**)&igTreePop, "igTreePop");
                 bindFunc(cast(void**)&igTreeAdvanceToLabelPos, "igTreeAdvanceToLabelPos");
                 bindFunc(cast(void**)&igGetTreeNodeToLabelSpacing, "igGetTreeNodeToLabelSpacing");
-                bindFunc(cast(void**)&igSetNextTreeNodeOpened, "igSetNextTreeNodeOpened");
+                bindFunc(cast(void**)&igSetNextTreeNodeOpen, "igSetNextTreeNodeOpen");
                 bindFunc(cast(void**)&igCollapsingHeader, "igCollapsingHeader");
                 bindFunc(cast(void**)&igCollapsingHeaderEx, "igCollapsingHeaderEx");
 

--- a/source/derelict/imgui/imgui.d
+++ b/source/derelict/imgui/imgui.d
@@ -286,6 +286,11 @@ final class DerelictImguiLoader : SharedLibLoader
                 bindFunc(cast(void**)&igTreeNodePtr, "igTreeNodePtr");
                 bindFunc(cast(void**)&igTreeNodeStrV, "igTreeNodeStrV");
                 bindFunc(cast(void**)&igTreeNodePtrV, "igTreeNodePtrV");
+                bindFunc(cast(void**)&igTreeNodeEx, "igTreeNodeEx");
+                bindFunc(cast(void**)&igTreeNodeExStr, "igTreeNodeExStr");
+                bindFunc(cast(void**)&igTreeNodeExPtr, "igTreeNodeExPtr");
+                bindFunc(cast(void**)&igTreeNodeExV, "igTreeNodeExV");
+                bindFunc(cast(void**)&igTreeNodeExVPtr, "igTreeNodeExVPtr");
                 bindFunc(cast(void**)&igTreePushStr, "igTreePushStr");
                 bindFunc(cast(void**)&igTreePushPtr, "igTreePushPtr");
                 bindFunc(cast(void**)&igTreePop, "igTreePop");

--- a/source/derelict/imgui/imgui.d
+++ b/source/derelict/imgui/imgui.d
@@ -294,6 +294,8 @@ final class DerelictImguiLoader : SharedLibLoader
                 bindFunc(cast(void**)&igTreePushStr, "igTreePushStr");
                 bindFunc(cast(void**)&igTreePushPtr, "igTreePushPtr");
                 bindFunc(cast(void**)&igTreePop, "igTreePop");
+                bindFunc(cast(void**)&igTreeAdvanceToLabelPos, "igTreeAdvanceToLabelPos");
+                bindFunc(cast(void**)&igGetTreeNodeToLabelSpacing, "igGetTreeNodeToLabelSpacing");
                 bindFunc(cast(void**)&igSetNextTreeNodeOpened, "igSetNextTreeNodeOpened");
 
                 bindFunc(cast(void**)&igSelectable, "igSelectable");

--- a/source/derelict/imgui/imgui.d
+++ b/source/derelict/imgui/imgui.d
@@ -322,6 +322,9 @@ final class DerelictImguiLoader : SharedLibLoader
                 bindFunc(cast(void**)&igLogButtons, "igLogButtons");
                 bindFunc(cast(void**)&igLogText, "igLogText");
 
+                bindFunc(cast(void**)&igPushClipRect, "igPushClipRect");
+                bindFunc(cast(void**)&igPopClipRect, "igPopClipRect");
+
                 bindFunc(cast(void**)&igIsItemHovered, "igIsItemHovered");
                 bindFunc(cast(void**)&igIsItemHoveredRect, "igIsItemHoveredRect");
                 bindFunc(cast(void**)&igIsItemActive, "igIsItemActive");

--- a/source/derelict/imgui/imgui.d
+++ b/source/derelict/imgui/imgui.d
@@ -339,6 +339,7 @@ final class DerelictImguiLoader : SharedLibLoader
                 bindFunc(cast(void**)&igIsWindowFocused, "igIsWindowFocused");
                 bindFunc(cast(void**)&igIsRootWindowFocused, "igIsRootWindowFocused");
                 bindFunc(cast(void**)&igIsRootWindowOrAnyChildFocused, "igIsRootWindowOrAnyChildFocused");
+                bindFunc(cast(void**)&igIsRootWindowOrAnyChildHovered, "igIsRootWindowOrAnyChildHovered");
                 bindFunc(cast(void**)&igIsRectVisible, "igIsRectVisible");
 
                 bindFunc(cast(void**)&igGetKeyIndex, "igGetKeyIndex");

--- a/source/derelict/imgui/imgui.d
+++ b/source/derelict/imgui/imgui.d
@@ -472,6 +472,10 @@ final class DerelictImguiLoader : SharedLibLoader
             bindFunc(cast(void**)&ImGuiIO_AddInputCharacter, "ImGuiIO_AddInputCharacter");
             bindFunc(cast(void**)&ImGuiIO_AddInputCharactersUTF8, "ImGuiIO_AddInputCharactersUTF8");
             bindFunc(cast(void**)&ImGuiIO_ClearInputCharacters, "ImGuiIO_ClearInputCharacters");
+
+            bindFunc(cast(void**)&ImGuiListClipper_Begin, "ImGuiListClipper_Begin");
+            bindFunc(cast(void**)&ImGuiListClipper_End, "ImGuiListClipper_End");
+            bindFunc(cast(void**)&ImGuiListClipper_Step, "ImGuiListClipper_Step");
         }
     }
 

--- a/source/derelict/imgui/imgui.d
+++ b/source/derelict/imgui/imgui.d
@@ -375,6 +375,12 @@ final class DerelictImguiLoader : SharedLibLoader
                 bindFunc(cast(void**)&igGetClipboardText, "igGetClipboardText");
                 bindFunc(cast(void**)&igSetClipboardText, "igSetClipboardText");
 
+                bindFunc(cast(void**)&igGetVersion, "igGetVersion");
+                bindFunc(cast(void**)&igCreateContext, "igCreateContext");
+                bindFunc(cast(void**)&igDestroyContext, "igDestroyContext");
+                bindFunc(cast(void**)&igGetCurrentContext, "igGetCurrentContext");
+                bindFunc(cast(void**)&igSetCurrentContext, "igSetCurrentContext");
+
                 bindFunc(cast(void**)&igGetTime, "igGetTime");
                 bindFunc(cast(void**)&igGetFrameCount, "igGetFrameCount");
                 bindFunc(cast(void**)&igGetStyleColName, "igGetStyleColName");
@@ -390,11 +396,6 @@ final class DerelictImguiLoader : SharedLibLoader
                 bindFunc(cast(void**)&igColorConvertFloat4ToU32, "igColorConvertFloat4ToU32");
                 bindFunc(cast(void**)&igColorConvertRGBtoHSV, "igColorConvertRGBtoHSV");
                 bindFunc(cast(void**)&igColorConvertHSVtoRGB, "igColorConvertHSVtoRGB");
-
-                bindFunc(cast(void**)&igGetVersion, "igGetVersion");
-                bindFunc(cast(void**)&igGetInternalState, "igGetInternalState");
-                bindFunc(cast(void**)&igGetInternalStateSize, "igGetInternalStateSize");
-                bindFunc(cast(void**)&igSetInternalState, "igSetInternalState");
             }
 
             {

--- a/source/derelict/imgui/imgui.d
+++ b/source/derelict/imgui/imgui.d
@@ -108,6 +108,7 @@ final class DerelictImguiLoader : SharedLibLoader
                 bindFunc(cast(void**)&igSetNextWindowPos, "igSetNextWindowPos");
                 bindFunc(cast(void**)&igSetNextWindowPosCenter, "igSetNextWindowPosCenter");
                 bindFunc(cast(void**)&igSetNextWindowSize, "igSetNextWindowSize");
+                bindFunc(cast(void**)&igSetNextWindowSizeConstraints, "igSetNextWindowSizeConstraints");
                 bindFunc(cast(void**)&igSetNextWindowCollapsed, "igSetNextWindowCollapsed");
                 bindFunc(cast(void**)&igSetNextWindowFocus, "igSetNextWindowFocus");
                 bindFunc(cast(void**)&igSetWindowPos, "igSetWindowPos");

--- a/source/derelict/imgui/imgui.d
+++ b/source/derelict/imgui/imgui.d
@@ -175,6 +175,7 @@ final class DerelictImguiLoader : SharedLibLoader
                 bindFunc(cast(void**)&igEndGroup, "igEndGroup");
                 bindFunc(cast(void**)&igSeparator, "igSeparator");
                 bindFunc(cast(void**)&igSameLine, "igSameLine");
+                bindFunc(cast(void**)&igNewLine, "igNewLine");
                 bindFunc(cast(void**)&igSpacing, "igSpacing");
                 bindFunc(cast(void**)&igDummy, "igDummy");
                 bindFunc(cast(void**)&igIndent, "igIndent");

--- a/source/derelict/imgui/imgui.d
+++ b/source/derelict/imgui/imgui.d
@@ -336,6 +336,7 @@ final class DerelictImguiLoader : SharedLibLoader
                 bindFunc(cast(void**)&igIsItemHovered, "igIsItemHovered");
                 bindFunc(cast(void**)&igIsItemHoveredRect, "igIsItemHoveredRect");
                 bindFunc(cast(void**)&igIsItemActive, "igIsItemActive");
+                bindFunc(cast(void**)&igIsItemActive, "igIsItemClicked");
                 bindFunc(cast(void**)&igIsItemVisible, "igIsItemVisible");
                 bindFunc(cast(void**)&igIsAnyItemHovered, "igIsAnyItemHovered");
                 bindFunc(cast(void**)&igIsAnyItemActive, "igIsAnyItemActive");

--- a/source/derelict/imgui/imgui.d
+++ b/source/derelict/imgui/imgui.d
@@ -230,7 +230,6 @@ final class DerelictImguiLoader : SharedLibLoader
                 bindFunc(cast(void**)&igInvisibleButton, "igInvisibleButton");
                 bindFunc(cast(void**)&igImage, "igImage");
                 bindFunc(cast(void**)&igImageButton, "igImageButton");
-                bindFunc(cast(void**)&igCollapsingHeader, "igCollapsingHeader");
                 bindFunc(cast(void**)&igCheckbox, "igCheckbox");
                 bindFunc(cast(void**)&igCheckboxFlags, "igCheckboxFlags");
                 bindFunc(cast(void**)&igRadioButtonBool, "igRadioButtonBool");
@@ -298,6 +297,8 @@ final class DerelictImguiLoader : SharedLibLoader
                 bindFunc(cast(void**)&igTreeAdvanceToLabelPos, "igTreeAdvanceToLabelPos");
                 bindFunc(cast(void**)&igGetTreeNodeToLabelSpacing, "igGetTreeNodeToLabelSpacing");
                 bindFunc(cast(void**)&igSetNextTreeNodeOpened, "igSetNextTreeNodeOpened");
+                bindFunc(cast(void**)&igCollapsingHeader, "igCollapsingHeader");
+                bindFunc(cast(void**)&igCollapsingHeaderEx, "igCollapsingHeaderEx");
 
                 bindFunc(cast(void**)&igSelectable, "igSelectable");
                 bindFunc(cast(void**)&igSelectableEx, "igSelectableEx");

--- a/source/derelict/imgui/types.d
+++ b/source/derelict/imgui/types.d
@@ -269,6 +269,7 @@ alias int ImGuiWindowFlags;       // enum ImGuiWindowFlags_
 alias int ImGuiSetCond;           // enum ImGuiSetCond_
 alias int ImGuiInputTextFlags;    // enum ImGuiInputTextFlags_
 alias int ImGuiSelectableFlags;   // enum ImGuiSelectableFlags_
+alias int ImGuiTreeNodeFlags;     // enum ImGuiTreeNodeFlags_
 alias int function(ImGuiTextEditCallbackData *data) ImGuiTextEditCallback;
 alias void function(ImGuiSizeConstraintCallbackData *data) ImGuiSizeConstraintCallback;
 

--- a/source/derelict/imgui/types.d
+++ b/source/derelict/imgui/types.d
@@ -527,28 +527,28 @@ align(1) struct ImColor
 }
 
 align(1) struct ImGuiListClipper {
-    import derelict.imgui.funcs : igCalcListClipping, igGetCursorPosY, igSetCursorPosY;
-    
-    float itemsHeight = 0f;
-    int itemsCount = -1, displayStart = -1, displayEnd = -1;
-    
-    this(int count, float height) {
-        itemsCount = -1;
-        Begin(count, height);
+	import derelict.imgui.funcs : ImGuiListClipper_Begin, ImGuiListClipper_End, ImGuiListClipper_Step;
+	
+	float StartPosY;
+    float ItemsHeight;
+	int ItemsCount, StepNo, DisplayStart, DisplayEnd;
+	
+	this(int items_count = -1, float items_height = -1.0f)
+    {
+		ImGuiListClipper_Begin(&this, items_count, items_height);
+	}
+
+    ~this()
+    {
+        assert(ItemsCount == -1);
     }
-    
-    void Begin(int count, float height) {
-        assert(itemsCount == -1);
-        itemsCount = count;
-        itemsHeight = height;
-        igCalcListClipping(itemsCount, itemsHeight, &displayStart, &displayEnd);
-        igSetCursorPosY(igGetCursorPosY() + displayStart * itemsHeight);
+
+    void Begin(int items_count, float items_height = -1.0f)
+    {
+        ImGuiListClipper_Begin(&this, items_count, items_height);
     }
-    
-    void End() {
-        assert(itemsCount >= 0);
-        igSetCursorPosY(igGetCursorPosY() + (itemsCount - displayEnd) * itemsHeight);
-        itemsCount = -1;
-    }
+
+    void End() { ImGuiListClipper_End(&this); }
+    bool Step() { return ImGuiListClipper_Step(&this); }
 }
 

--- a/source/derelict/imgui/types.d
+++ b/source/derelict/imgui/types.d
@@ -498,29 +498,89 @@ align(1) struct ImColor
     }
 }
 
+private void SetCursorPosYAndSetupDummyPrevLine(float pos_y, float line_height)
+{
+    igSetCursorPosY(pos_y);
+    ImGuiWindow* window = igGetCurrentWindow();
+    window.DC.CursorPosPrevLine.y = window.DC.CursorPos.y - line_height;
+    window.DC.PrevLineHeight = (line_height - igGetCurrentContext().Style.ItemSpacing.y);
+}
+
 align(1) struct ImGuiListClipper {
 	import derelict.imgui.funcs : igCalcListClipping, igGetCursorPosY, igSetCursorPosY;
 	
-	float itemsHeight = 0f;
-	int itemsCount = -1, displayStart = -1, displayEnd = -1;
+	float startPosY;
+    float itemsHeight;
+	int itemsCount, stepNo, displayStart, displayEnd;
 	
-	this(int count, float height) {
-		itemsCount = -1;
-		Begin(count, height);
+	this(int items_count = -1, float items_height = -1.0f) {
+		Begin(items_count, items_height);
 	}
+
+    ~this() {
+        assert(itemsCount == -1);
+    }
+
+    bool Step() {
+        if (itemsCount == 0 || igGetCurrentContext().CurrentWindow.SkipItems)
+        {
+            itemsCount = -1;
+            return false;
+        }
+        if (stepNo == 0)
+        {
+            displayStart = 0;
+            displayEnd = 1;
+            startPosY = igGetCursorPosY();
+            stepNo = 1;
+            return true;
+        }
+        if (stepNo == 1)
+        {
+            if (itemsCount == 1) {
+                itemsCount = -1;
+                return false;
+            }
+            float items_height = igGetCursorPosY() - startPosY;
+            assert(items_height > 0.0f);
+            igSetCursorPosY(startPosY);
+            Begin(itemsCount, items_height);
+            stepNo = 3;
+            return true;
+        }
+        if (stepNo == 2)
+        {
+            assert(displayStart >= 0 && displayEnd >= 0);
+            stepNo = 3;
+            return true;
+        }
+        if (stepNo == 3)
+            End();
+        return false;
+    }
 	
-	void Begin(int count, float height) {
-		assert(itemsCount == -1);
-		itemsCount = count;
-		itemsHeight = height;
-		igCalcListClipping(itemsCount, itemsHeight, &displayStart, &displayEnd);
-		igSetCursorPosY(igGetCursorPosY() + displayStart * itemsHeight);
+	void Begin(int items_count, float items_height = -1.0f) {
+        startPosY = igGetCursorPosY();
+        itemsHeight = items_height;
+        itemsCount = items_count;
+        stepNo = 0;
+        displayEnd = displayStart = -1;
+        if (itemsHeight > 0.0f)
+        {
+            igCalcListClipping(itemsCount, itemsHeight, &displayStart, &displayEnd);
+            if (displayStart > 0)
+                SetCursorPosYAndSetupDummyPrevLine(startPosY + displayStart * itemsHeight, itemsHeight);
+            stepNo = 2;
+        }
 	}
 	
 	void End() {
-		assert(itemsCount >= 0);
-		igSetCursorPosY(igGetCursorPosY() + (itemsCount - displayEnd) * itemsHeight);
-		itemsCount = -1;
+		if (itemsCount < 0)
+            return;
+        if (itemsCount < int.max)
+            SetCursorPosYAndSetupDummyPrevLine(startPosY + itemsCount * itemsHeight, itemsHeight);
+        itemsCount = -1;
+        stepNo = 3;
 	}
 }
 

--- a/source/derelict/imgui/types.d
+++ b/source/derelict/imgui/types.d
@@ -252,6 +252,7 @@ alias int ImGuiSetCond;           // enum ImGuiSetCond_
 alias int ImGuiInputTextFlags;    // enum ImGuiInputTextFlags_
 alias int ImGuiSelectableFlags;   // enum ImGuiSelectableFlags_
 alias int function(ImGuiTextEditCallbackData *data) ImGuiTextEditCallback;
+alias void function(ImGuiSizeConstraintCallbackData *data) ImGuiSizeConstraintCallback;
 
 extern(C) nothrow {
     alias RenderDrawListFunc = void function(ImDrawData* data);
@@ -459,6 +460,14 @@ align(1) struct ImFontConfig
     // [Internal]
     char[32]        Name;
     ImFont*         DstFont;
+}
+
+align(1) struct ImGuiSizeConstraintCallbackData
+{
+    void*           UserData;
+    ImVec2          Pos;
+    ImVec2          CurrentSize;
+    ImVec2          DesiredSize;
 }
 
 align(1) struct ImColor

--- a/source/derelict/imgui/types.d
+++ b/source/derelict/imgui/types.d
@@ -253,6 +253,7 @@ struct ImFont{}
 struct ImFontAtlas{}
 struct ImDrawList{}
 struct ImGuiStorage{}
+struct ImGuiContext{}
 
 alias uint ImU32;
 alias ushort ImWchar;     // character for display

--- a/source/derelict/imgui/types.d
+++ b/source/derelict/imgui/types.d
@@ -110,6 +110,23 @@ enum
 
 enum
 {
+    ImGuiTreeNodeFlags_Selected             = 1 << 0,   // Draw as selected
+    ImGuiTreeNodeFlags_Framed               = 1 << 1,   // Full colored frame (e.g. for CollapsingHeader)
+    ImGuiTreeNodeFlags_AllowOverlapMode     = 1 << 2,   // Hit testing to allow subsequent widgets to overlap this one
+    ImGuiTreeNodeFlags_NoTreePushOnOpen     = 1 << 3,   // Don't do a TreePush() when open (e.g. for CollapsingHeader) = no extra indent nor pushing on ID stack
+    ImGuiTreeNodeFlags_NoAutoOpenOnLog      = 1 << 4,   // Don't automatically and temporarily open node when Logging is active (by default logging will automatically open tree nodes)
+    ImGuiTreeNodeFlags_DefaultOpen          = 1 << 5,   // Default node to be open
+    ImGuiTreeNodeFlags_OpenOnDoubleClick    = 1 << 6,   // Need double-click to open node
+    ImGuiTreeNodeFlags_OpenOnArrow          = 1 << 7,   // Only open when clicking on the arrow part. If ImGuiTreeNodeFlags_OpenOnDoubleClick is also set, single-click arrow or double-click all box to open.
+    ImGuiTreeNodeFlags_Leaf                 = 1 << 8,   // No collapsing, no arrow (use as a convenience for leaf nodes). 
+    ImGuiTreeNodeFlags_Bullet               = 1 << 9,   // Display a bullet instead of arrow
+    //ImGuITreeNodeFlags_SpanAllAvailWidth  = 1 << 10,  // FIXME: TODO: Extend hit box horizontally even if not framed
+    //ImGuiTreeNodeFlags_NoScrollOnOpen     = 1 << 11,  // FIXME: TODO: Disable automatic scroll on TreePop() if node got just open and contents is not visible
+    ImGuiTreeNodeFlags_CollapsingHeader     = ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_NoAutoOpenOnLog
+}
+
+enum
+{
     // Default: 0
     ImGuiSelectableFlags_DontClosePopups    = 1 << 0,   // Clicking this don't close parent popup window
     ImGuiSelectableFlags_SpanAllColumns     = 1 << 1,    // Selectable frame can span all columns (text will still fit in current column)


### PR DESCRIPTION
This implements all API changes listed in [the changelog](https://github.com/ocornut/imgui/releases/tag/v1.49). It builds and runs the [demo](https://github.com/Extrawurst/imgui_d_test) fine (with the right cimgui library), but I haven't done any more testing yet.

Because the new `ImGuiListClipper` code requires access to the internal `ImGuiWindow` structure it had to be bound instead of reimplemented in D. This required changes to `cimgui` (see my [pull request](https://github.com/Extrawurst/cimgui/pull/19)).
